### PR TITLE
$.argsToArray should be moved to a jquery.evently.util.js module

### DIFF
--- a/vendor/_attachments/jquery.couch.app.util.js
+++ b/vendor/_attachments/jquery.couch.app.util.js
@@ -22,13 +22,13 @@ $.fn.serializeObject = function() {
 };
 
 // todo remove this crap
-function escapeHTML(st) {                                       
-  return(                                                                 
-    st && st.replace(/&/g,'&amp;').                                         
-      replace(/>/g,'&gt;').                                           
-      replace(/</g,'&lt;').                                           
-      replace(/"/g,'&quot;')                                         
-  );                                                                     
+function escapeHTML(st) {
+  return(
+    st && st.replace(/&/g,'&amp;').
+      replace(/>/g,'&gt;').
+      replace(/</g,'&lt;').
+      replace(/"/g,'&quot;')
+  );
 };
 
 function safeHTML(st, len) {
@@ -59,7 +59,7 @@ $.fn.prettyDate = function() {
 };
 
 $.prettyDate = function(time){
-  
+
 	var date = new Date(time.replace(/-/g,"/").replace("T", " ").replace("Z", " +0000").replace(/(\d*\:\d*:\d*)\.\d*/g,"$1")),
 		diff = (((new Date()).getTime() - date.getTime()) / 1000),
 		day_diff = Math.floor(diff / 86400);
@@ -79,12 +79,3 @@ $.prettyDate = function(time){
     // day_diff < 730 && Math.ceil( day_diff / 31 ) + " months ago" ||
     // Math.ceil( day_diff / 365 ) + " years ago";
 };
-
-$.argsToArray = function(args) {
-  if (!args.callee) return args;
-  var array = [];
-  for (var i=0; i < args.length; i++) {
-    array.push(args[i]);
-  };
-  return array;
-}

--- a/vendor/_attachments/jquery.evently.util.js
+++ b/vendor/_attachments/jquery.evently.util.js
@@ -1,0 +1,8 @@
+$.argsToArray = function(args) {
+  if (!args.callee) return args;
+  var array = [];
+  for (var i=0; i < args.length; i++) {
+    array.push(args[i]);
+  };
+  return array;
+}

--- a/vendor/_attachments/loader.js
+++ b/vendor/_attachments/loader.js
@@ -13,5 +13,6 @@ couchapp_load([
   "vendor/couchapp/jquery.couch.app.js",
   "vendor/couchapp/jquery.couch.app.util.js",
   "vendor/couchapp/jquery.mustache.js",
-  "vendor/couchapp/jquery.evently.js"
+  "vendor/couchapp/jquery.evently.js",
+  "vendor/couchapp/jquery.evently.util.js"
 ]);


### PR DESCRIPTION
$.argsToArray is only used inside evently. To use evently standalone, it needs to be included. Instead of bring all of jquery.couch.app.js and jquery.couch.app.util.js over to evently, it makes more sense to split the evently specific utils out to their own module.
