### PR TITLE
Have path.js support _rewrite paths

### DIFF
--- a/couchapp/templates/vendor/lib/path.js
+++ b/couchapp/templates/vendor/lib/path.js
@@ -61,6 +61,10 @@ exports.init = function(req) {
       var p = req.path, parts = ['', p[0], p[1] , p[2], '_update'];
       return makePath(concatArgs(parts, arguments));
     },
+    rewrite: function() {
+      var p = req.path, parts = ['', p[0], p[1] , p[2], '_rewrite'];
+      return makePath(concatArgs(parts, arguments));
+    },
     limit : function(limit) {
       var query = req.query;
       var l = query.limit;


### PR DESCRIPTION
This patch will let you use path.js to build paths to _rewrite locations on your ddoc with ease.
