### PR TITLE
Allow overriding of login templates

### DIFF
--- a/couchapp/templates/vendor/couchapp/_attachments/jquery.couchLogin.js
+++ b/couchapp/templates/vendor/couchapp/_attachments/jquery.couchLogin.js
@@ -13,8 +13,17 @@
 //    });
 
 (function($) {
+    $.couchLogin = {};
+    $.couchLogin.templates = {
+        adminParty : '<p><strong>Admin party, everyone is admin!</strong> Fix this in <a href="/_utils/index.html">Futon</a> before proceeding.</p>',
+        loggedOut : '<a href="#signup">Signup</a> or <a href="#login">Login</a>',
+        loginForm : '<form class="login"><label for="name">Name</label> <input type="text" name="name" value="" autocapitalize="off" autocorrect="off"><label for="password">Password</label> <input type="password" name="password" value=""><input type="submit" value="Login"><a href="#signup">or Signup</a></form>',
+        signupForm : '<form class="signup"><label for="name">Name</label> <input type="text" name="name" value="" autocapitalize="off" autocorrect="off"><label for="password">Password</label> <input type="password" name="password" value=""><input type="submit" value="Signup"><a href="#login">or Login</a></form>'
+    };
+
     $.fn.couchLogin = function(opts) {
         var elem = $(this);
+        var templates = $.couchLogin.templates;
         opts = opts || {};
         function initWidget() {
             $.couch.session({
@@ -65,12 +74,7 @@
             return false;      
         });
     }
-    var templates = {
-        adminParty : '<p><strong>Admin party, everyone is admin!</strong> Fix this in <a href="/_utils/index.html">Futon</a> before proceeding.</p>',
-        loggedOut : '<a href="#signup">Signup</a> or <a href="#login">Login</a>',
-        loginForm : '<form class="login"><label for="name">Name</label> <input type="text" name="name" value="" autocapitalize="off" autocorrect="off"><label for="password">Password</label> <input type="password" name="password" value=""><input type="submit" value="Login"><a href="#signup">or Signup</a></form>',
-        signupForm : '<form class="signup"><label for="name">Name</label> <input type="text" name="name" value="" autocapitalize="off" autocorrect="off"><label for="password">Password</label> <input type="password" name="password" value=""><input type="submit" value="Signup"><a href="#login">or Login</a></form>'
-    };
+
     function loggedIn(r) {
         var auth_db = encodeURIComponent(r.info.authentication_db)
         , uri_name = encodeURIComponent(r.userCtx.name)


### PR DESCRIPTION
In the couchLogin jquery plugin, the templates must be allowed to be
overridden in applications, as done in the profile plugin.
