### PR TITLE
FIX: update functions are lost during cloning of a design doc

### DIFF
--- a/couchapp/clone_app.py
+++ b/couchapp/clone_app.py
@@ -153,7 +153,7 @@ def clone(source, dest=None, rev=None):
                     filename = os.path.join(vs_item_dir, '%s.js' % func_name)
                     util.write(filename, func)
                     logger.warning("clone view not in manifest: %s" % filename)
-        elif key in ('shows', 'lists', 'filter', 'update'):
+        elif key in ('shows', 'lists', 'filter', 'updates'):
             showpath = os.path.join(path, key)
             if not os.path.isdir(showpath):
                 os.makedirs(showpath)


### PR DESCRIPTION
To reproduce the issue we need only a design doc with one or several update functions. When we run the following command on such a ddoc, the update functions are lost.

```
couchapp clone http://127.0.0.1:5984/testdb/_design/helloworld helloworld
```

Due to official docs 'updates' but not 'update' should be used as a directory name:
http://wiki.apache.org/couchdb/Document_Update_Handlers 
