### PR TITLE
Fix documentation: Add the curl -L location header flag to follow redire...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,7 @@ Couchapp requires Python 2.5x or greater. Couchapp is most easily installed
 using the latest versions of the standard python packaging tools, setuptools 
 and pip. They may be installed like so::
 
-    $ curl -O https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
-    $ sudo python ez_setup.py
-    $ curl -O -L https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+    $ curl -O https://bootstrap.pypa.io/get-pip.py
     $ sudo python get-pip.py
 
 Installing couchapp is then simply a matter of::


### PR DESCRIPTION
It looks like github now does a redirect from https://raw.github.com/pypa/pip/master/contrib/get-pip.py to https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py. Add the -L curl param to follow the redirect.
