### PR TITLE
Coverage rate improvement for dispatch.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,15 +61,15 @@ line.
 Note: On debian system don't forget to install python-dev.
 
 To install on Windows follow instructions `here
-<http://www.couchapp.org/page/windows-python-installers>`_.
+<https://github.com/couchapp/couchapp/blob/master/docs/couchapp-org/installing.md#installing-on-windows>`_.
 
 More installation options on the `website
-<http://www.couchapp.org/page/installing>`_.
+<https://github.com/couchapp/couchapp/blob/master/docs/couchapp-org/installing.md>`_.
 
 Getting started
 ---------------
 
-Read the `tutorial <http://www.couchapp.org/page/getting-started>`_.
+Read the `tutorial <https://github.com/couchapp/couchapp/blob/master/docs/gettingstarted.md>`_.
 
 Testing
 -------
@@ -94,9 +94,8 @@ Thanks for testing ``couchapp``!
 Other resources
 ---------------
 
-* `Couchapp website <http://couchapp.org>`_
-* `Frequently Asked Questions <http://couchapp.org/page/faq>`_
-* `couchapp command line usage <http://couchapp.org/page/couchapp-usage>`_
-* `Extend couchapp command line <http://couchapp.org/page/couchapp-extend>`_
-* `List of CouchApps <http://couchapp.org/page/list-of-couchapps>`_
+* `Couchapp website archive <https://github.com/couchapp/couchapp/tree/master/docs/couchapp-org>`_
+* `couchapp command line usage <https://github.com/couchapp/couchapp/blob/master/docs/usage.md>`_
+* `Extend couchapp command line <https://github.com/couchapp/couchapp/blob/master/docs/extends.md>`_
+* `List of CouchApps <https://github.com/couchapp/couchapp/blob/master/docs/couchapp-org/list-of-couchapps.md>`_
 

--- a/couchapp/autopush/watcher.py
+++ b/couchapp/autopush/watcher.py
@@ -38,7 +38,7 @@ class CouchappWatcher(object):
                                self.doc_path, recursive=True)
 
     def init_signals(self):
-        """\
+        """
         Initialize master signal handling. Most of the signals
         are queued. Child signals only wake up the master.
         """

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -386,6 +386,7 @@ def get_switch_str(opt):
         # only has a long option
         return "--%s %s" % (opt[1], default)
 
+
 globalopts = [
     ('d', 'debug', None, "debug mode"),
     ('h', 'help', None, "display help and exit"),
@@ -403,52 +404,60 @@ pushopts = [
 ]
 
 table = {
-    "init":
-    (init,
-     [],
-     "[COUCHAPPDIR]"),
-    "push":
-    (push,
-     pushopts + [('', 'docid', '', "set docid")],
-     "[OPTION]... [COUCHAPPDIR] DEST"),
-    "clone":
-    (clone,
-     [('r', 'rev', '', "clone specific revision")],
-     "[OPTION]...[-r REV] SOURCE [COUCHAPPDIR]"),
-    "pushapps":
-    (pushapps,
-     pushopts,
-     "[OPTION]... SOURCE DEST"),
-    "pushdocs":
-    (pushdocs,
-     pushopts,
-     "[OPTION]... SOURCE DEST"),
-    "startapp":
-    (startapp,
-     [],
-     "[COUCHAPPDIR] NAME"),
-    "generate":
-    (generate,
-     [('', 'template', '', "template name")],
-     "[OPTION]... [app|view,list,show,filter,function,vendor] [COUCHAPPDIR] "
-     + "NAME"),
-    "vendor":
-    (vendor,
-     [("f", 'force', False, "force install or update")],
-     "[OPTION]...[-f] install|update [COUCHAPPDIR] SOURCE"),
-    "browse":
-    (browse,
-     [],
-     "[COUCHAPPDIR] DEST"),
-    "autopush":
-    (autopush,
-     [('', 'no-atomic', False, "send attachments one by one"),
-      ('', 'update-delay', DEFAULT_UPDATE_DELAY, "time between each update")],
-     "[OPTION]... [COUCHAPPDIR] DEST"),
-    "help":
-    (usage, [], ""),
-    "version":
-    (version, [], "")
+    "init": (
+        init,
+        [],
+        "[COUCHAPPDIR]"
+    ),
+    "push": (
+        push,
+        pushopts + [('', 'docid', '', "set docid")],
+        "[OPTION]... [COUCHAPPDIR] DEST"
+    ),
+    "clone": (
+        clone,
+        [('r', 'rev', '', "clone specific revision")],
+        "[OPTION]...[-r REV] SOURCE [COUCHAPPDIR]"
+    ),
+    "pushapps": (
+        pushapps,
+        pushopts,
+        "[OPTION]... SOURCE DEST"
+    ),
+    "pushdocs": (
+        pushdocs,
+        pushopts,
+        "[OPTION]... SOURCE DEST"
+    ),
+    "startapp": (
+        startapp,
+        [],
+        "[COUCHAPPDIR] NAME"
+    ),
+    "generate": (
+        generate,
+        [('', 'template', '', "template name")],
+        ("[OPTION]... [app|view,list,show,filter,function,vendor]"
+         " [COUCHAPPDIR] NAME")
+     ),
+    "vendor": (
+        vendor,
+        [("f", 'force', False, "force install or update")],
+        "[OPTION]...[-f] install|update [COUCHAPPDIR] SOURCE"
+    ),
+    "browse": (
+        browse,
+        [],
+        "[COUCHAPPDIR] DEST"
+    ),
+    "autopush": (
+        autopush,
+        [('', 'no-atomic', False, "send attachments one by one"),
+         ('', 'update-delay', DEFAULT_UPDATE_DELAY, "time between each update")],
+        "[OPTION]... [COUCHAPPDIR] DEST"
+     ),
+    "help": (usage, [], ""),
+    "version": (version, [], "")
 }
 
 withcmd = ['generate', 'vendor']

--- a/couchapp/dispatch.py
+++ b/couchapp/dispatch.py
@@ -49,11 +49,11 @@ def dispatch(args):
 
     try:
         return _dispatch(args)
-    except AppError, e:
+    except AppError as e:
         logger.error("couchapp error: %s" % str(e))
     except KeyboardInterrupt:
         logger.info("keyboard interrupt")
-    except Exception, e:
+    except Exception as e:
         import traceback
 
         logger.critical("%s\n\n%s" % (str(e), traceback.format_exc()))
@@ -88,8 +88,8 @@ def _dispatch(args):
         verbose = 0
 
     set_logging_level(verbose)
-    if cmd is None:
-        raise CommandLineError("unknown command")
+    if cmd not in commands.table:
+        raise CommandLineError('Unknown command: "{}"'.format(cmd))
 
     fun = commands.table[cmd][0]
     if cmd in commands.incouchapp:
@@ -103,7 +103,7 @@ def _parse(args):
     cmdoptions = {}
     try:
         args = parseopts(args, commands.globalopts, options)
-    except getopt.GetoptError, e:
+    except getopt.GetoptError as e:
         raise CommandLineError(str(e))
 
     if args:
@@ -121,7 +121,7 @@ def _parse(args):
 
     try:
         args = parseopts(args, cmdopts, cmdoptions)
-    except getopt.GetoptError, e:
+    except getopt.GetoptError as e:
         raise CommandLineError((cmd, e))
 
     for opt in cmdoptions.keys():

--- a/couchapp/dispatch.py
+++ b/couchapp/dispatch.py
@@ -51,6 +51,8 @@ def dispatch(args):
         return _dispatch(args)
     except AppError as e:
         logger.error("couchapp error: %s" % str(e))
+    except CommandLineError as e:
+        logger.error("command line error: {}".format(e))
     except KeyboardInterrupt:
         logger.info("keyboard interrupt")
     except Exception as e:

--- a/couchapp/dispatch.py
+++ b/couchapp/dispatch.py
@@ -52,7 +52,7 @@ def dispatch(args):
     except AppError as e:
         logger.error("couchapp error: %s" % str(e))
     except CommandLineError as e:
-        logger.error("command line error: {}".format(e))
+        logger.error("command line error: {0}".format(e))
     except KeyboardInterrupt:
         logger.info("keyboard interrupt")
     except Exception as e:

--- a/couchapp/generator.py
+++ b/couchapp/generator.py
@@ -61,7 +61,7 @@ def generate_app(path, template=None, create=False):
         prefix = os.path.join(*template.split('/'))
     try:
         os.makedirs(path)
-    except OSError, e:
+    except OSError as e:
         errno, message = e
         raise AppError("Can't create a CouchApp in %s: %s" % (path, message))
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -49,6 +49,24 @@ class DispatchTestCase(unittest.TestCase):
         with self.assertRaises(GetoptError):
             dispatch.parseopts(['--unkown'], globalopts, {})
 
+    def test_parseopts_list_option(self):
+        listopts = [('l', 'list', [], 'Test for list option')]
+        opts = {}
+        dispatch.parseopts(['-l', 'foo', '-l', 'bar'], listopts, opts)
+        assert opts['list'] == ['foo', 'bar']
+
+    def test_parseopts_int_option(self):
+        intopts = [('i', 'int', 100, 'Test for int option')]
+        opts = {}
+        dispatch.parseopts(['-i', '200'], intopts, opts)
+        assert opts['int'] == 200
+
+    def test_parseopts_str_option(self):
+        stropts = [('s', 'str', '', 'Test for int option')]
+        opts = {}
+        dispatch.parseopts(['-s', 'test'], stropts, opts)
+        assert opts['str'] == 'test'
+
     def test__parse_invalid_flag(self):
         with self.assertRaises(CommandLineError):
             dispatch._parse(['-X'])
@@ -74,6 +92,21 @@ class DispatchTestCase(unittest.TestCase):
         cmd, options, cmdoptions, args = dispatch._parse(['push', '-b', 'http://localhost'])
         assert cmd == 'push'
         assert cmdoptions['browse'] == True
+
+    def test__dispatch_debug(self):
+        assert dispatch._dispatch(['-d']) == 0
+
+    def test__dispatch_help(self):
+        assert dispatch._dispatch(['-h']) == 0
+
+    def test__dispatch_verbose(self):
+        assert dispatch._dispatch(['-v']) == 0
+
+    def test__dispatch_version(self):
+        assert dispatch._dispatch(['--version']) == 0
+
+    def test__dispatch_quiet(self):
+        assert dispatch._dispatch(['-q']) == 0
 
 
 if __name__ == '__main__':

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -2,7 +2,10 @@
 
 import unittest2 as unittest
 
+from getopt import GetoptError
+
 from couchapp import dispatch
+from couchapp.commands import globalopts
 from couchapp.errors import CommandLineError
 
 
@@ -16,6 +19,61 @@ class DispatchTestCase(unittest.TestCase):
     def test_unknown_command(self):
         with self.assertRaises(CommandLineError):
             dispatch._dispatch(['unknown_command'])
+
+        assert dispatch.dispatch(['unknown_command']) == -1
+
+    def test_parseopts_short_flag(self):
+        opts = {}
+        args = dispatch.parseopts(['-v', 'generate', 'app', 'test-app'], globalopts, opts)
+        assert args == ['generate', 'app', 'test-app']
+        assert opts['debug'] is None
+        assert opts['help'] is None
+        assert opts['version'] is None
+        assert opts['verbose'] == True
+        assert opts['quiet'] is None
+
+    def test_parseopts_long_flag(self):
+        opts = {}
+        args = dispatch.parseopts(['--version'], globalopts, opts)
+        assert args == []
+        assert opts['debug'] is None
+        assert opts['help'] is None
+        assert opts['version'] == True
+        assert opts['verbose'] is None
+        assert opts['quiet'] is None
+
+    def test_parseopts_invalid_flag(self):
+        with self.assertRaises(GetoptError):
+            dispatch.parseopts(['-X'], globalopts, {})
+
+        with self.assertRaises(GetoptError):
+            dispatch.parseopts(['--unkown'], globalopts, {})
+
+    def test__parse_invalid_flag(self):
+        with self.assertRaises(CommandLineError):
+            dispatch._parse(['-X'])
+
+        with self.assertRaises(CommandLineError):
+            dispatch._parse(['init', '-X'])
+
+        with self.assertRaises(CommandLineError):
+            dispatch._parse(['--unkown'])
+
+    def test__parse_help(self):
+        cmd, options, cmdoptions, args = dispatch._parse(['help'])
+        assert cmd == 'help'
+
+        cmd, options, cmdoptions, args = dispatch._parse([])
+        assert cmd == 'help'
+
+        cmd, options, cmdoptions, args = dispatch._parse(['-h'])
+        assert cmd == 'help'
+        assert options['help'] == True
+
+    def test__parse_subcmd_options(self):
+        cmd, options, cmdoptions, args = dispatch._parse(['push', '-b', 'http://localhost'])
+        assert cmd == 'push'
+        assert cmdoptions['browse'] == True
 
 
 if __name__ == '__main__':

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -5,7 +5,7 @@ from getopt import GetoptError
 from couchapp import dispatch
 from couchapp.commands import globalopts
 from couchapp.errors import AppError, CommandLineError
-from nose.tools import assert_raises
+from nose.tools import raises
 from mock import Mock, patch
 
 
@@ -32,11 +32,16 @@ def test_parseopts_long_flag():
 
 
 def test_parseopts_invalid_flag():
-    with assert_raises(GetoptError):
+    @raises(GetoptError)
+    def short():
         dispatch.parseopts(['-X'], globalopts, {})
 
-    with assert_raises(GetoptError):
+    @raises(GetoptError)
+    def long():
         dispatch.parseopts(['--unkown'], globalopts, {})
+
+    short()
+    long()
 
 
 def test_parseopts_list_option():
@@ -61,14 +66,21 @@ def test_parseopts_str_option():
 
 
 def test__parse_invalid_flag():
-    with assert_raises(CommandLineError):
+    @raises(CommandLineError)
+    def short():
         dispatch._parse(['-X'])
 
-    with assert_raises(CommandLineError):
+    @raises(CommandLineError)
+    def app_arg():
         dispatch._parse(['init', '-X'])
 
-    with assert_raises(CommandLineError):
+    @raises(CommandLineError)
+    def long():
         dispatch._parse(['--unkown'])
+
+    short()
+    app_arg()
+    long()
 
 
 def test__parse_help():
@@ -115,9 +127,9 @@ def test__dispatch_quiet(set_logging_level):
     set_logging_level.assert_called_with(0)
 
 
+@raises(CommandLineError)
 def test__dispatch_unknown_command():
-    with assert_raises(CommandLineError):
-        dispatch._dispatch(['unknown_command'])
+    dispatch._dispatch(['unknown_command'])
 
 
 @patch('couchapp.dispatch.commands')

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,113 +1,114 @@
 # -*- coding: utf-8 -*-
 
-import unittest2 as unittest
-
 from getopt import GetoptError
 
 from couchapp import dispatch
 from couchapp.commands import globalopts
 from couchapp.errors import CommandLineError
+from nose.tools import assert_raises
 
 
-class DispatchTestCase(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_unknown_command(self):
-        with self.assertRaises(CommandLineError):
-            dispatch._dispatch(['unknown_command'])
-
-        assert dispatch.dispatch(['unknown_command']) == -1
-
-    def test_parseopts_short_flag(self):
-        opts = {}
-        args = dispatch.parseopts(['-v', 'generate', 'app', 'test-app'], globalopts, opts)
-        assert args == ['generate', 'app', 'test-app']
-        assert opts['debug'] is None
-        assert opts['help'] is None
-        assert opts['version'] is None
-        assert opts['verbose'] == True
-        assert opts['quiet'] is None
-
-    def test_parseopts_long_flag(self):
-        opts = {}
-        args = dispatch.parseopts(['--version'], globalopts, opts)
-        assert args == []
-        assert opts['debug'] is None
-        assert opts['help'] is None
-        assert opts['version'] == True
-        assert opts['verbose'] is None
-        assert opts['quiet'] is None
-
-    def test_parseopts_invalid_flag(self):
-        with self.assertRaises(GetoptError):
-            dispatch.parseopts(['-X'], globalopts, {})
-
-        with self.assertRaises(GetoptError):
-            dispatch.parseopts(['--unkown'], globalopts, {})
-
-    def test_parseopts_list_option(self):
-        listopts = [('l', 'list', [], 'Test for list option')]
-        opts = {}
-        dispatch.parseopts(['-l', 'foo', '-l', 'bar'], listopts, opts)
-        assert opts['list'] == ['foo', 'bar']
-
-    def test_parseopts_int_option(self):
-        intopts = [('i', 'int', 100, 'Test for int option')]
-        opts = {}
-        dispatch.parseopts(['-i', '200'], intopts, opts)
-        assert opts['int'] == 200
-
-    def test_parseopts_str_option(self):
-        stropts = [('s', 'str', '', 'Test for int option')]
-        opts = {}
-        dispatch.parseopts(['-s', 'test'], stropts, opts)
-        assert opts['str'] == 'test'
-
-    def test__parse_invalid_flag(self):
-        with self.assertRaises(CommandLineError):
-            dispatch._parse(['-X'])
-
-        with self.assertRaises(CommandLineError):
-            dispatch._parse(['init', '-X'])
-
-        with self.assertRaises(CommandLineError):
-            dispatch._parse(['--unkown'])
-
-    def test__parse_help(self):
-        cmd, options, cmdoptions, args = dispatch._parse(['help'])
-        assert cmd == 'help'
-
-        cmd, options, cmdoptions, args = dispatch._parse([])
-        assert cmd == 'help'
-
-        cmd, options, cmdoptions, args = dispatch._parse(['-h'])
-        assert cmd == 'help'
-        assert options['help'] == True
-
-    def test__parse_subcmd_options(self):
-        cmd, options, cmdoptions, args = dispatch._parse(['push', '-b', 'http://localhost'])
-        assert cmd == 'push'
-        assert cmdoptions['browse'] == True
-
-    def test__dispatch_debug(self):
-        assert dispatch._dispatch(['-d']) == 0
-
-    def test__dispatch_help(self):
-        assert dispatch._dispatch(['-h']) == 0
-
-    def test__dispatch_verbose(self):
-        assert dispatch._dispatch(['-v']) == 0
-
-    def test__dispatch_version(self):
-        assert dispatch._dispatch(['--version']) == 0
-
-    def test__dispatch_quiet(self):
-        assert dispatch._dispatch(['-q']) == 0
+def test_unknown_command():
+    with assert_raises(CommandLineError):
+        dispatch._dispatch(['unknown_command'])
+    assert dispatch.dispatch(['unknown_command']) == -1
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_parseopts_short_flag():
+    opts = {}
+    args = dispatch.parseopts(['-v', 'generate', 'app', 'test-app'], globalopts, opts)
+    assert args == ['generate', 'app', 'test-app']
+    assert opts['debug'] is None
+    assert opts['help'] is None
+    assert opts['version'] is None
+    assert opts['verbose'] == True
+    assert opts['quiet'] is None
+
+
+def test_parseopts_long_flag():
+    opts = {}
+    args = dispatch.parseopts(['--version'], globalopts, opts)
+    assert args == []
+    assert opts['debug'] is None
+    assert opts['help'] is None
+    assert opts['version'] == True
+    assert opts['verbose'] is None
+    assert opts['quiet'] is None
+
+
+def test_parseopts_invalid_flag():
+    with assert_raises(GetoptError):
+        dispatch.parseopts(['-X'], globalopts, {})
+
+    with assert_raises(GetoptError):
+        dispatch.parseopts(['--unkown'], globalopts, {})
+
+
+def test_parseopts_list_option():
+    listopts = [('l', 'list', [], 'Test for list option')]
+    opts = {}
+    dispatch.parseopts(['-l', 'foo', '-l', 'bar'], listopts, opts)
+    assert opts['list'] == ['foo', 'bar']
+
+
+def test_parseopts_int_option():
+    intopts = [('i', 'int', 100, 'Test for int option')]
+    opts = {}
+    dispatch.parseopts(['-i', '200'], intopts, opts)
+    assert opts['int'] == 200
+
+
+def test_parseopts_str_option():
+    stropts = [('s', 'str', '', 'Test for int option')]
+    opts = {}
+    dispatch.parseopts(['-s', 'test'], stropts, opts)
+    assert opts['str'] == 'test'
+
+
+def test__parse_invalid_flag():
+    with assert_raises(CommandLineError):
+        dispatch._parse(['-X'])
+
+    with assert_raises(CommandLineError):
+        dispatch._parse(['init', '-X'])
+
+    with assert_raises(CommandLineError):
+        dispatch._parse(['--unkown'])
+
+
+def test__parse_help():
+    cmd, options, cmdoptions, args = dispatch._parse(['help'])
+    assert cmd == 'help'
+
+    cmd, options, cmdoptions, args = dispatch._parse([])
+    assert cmd == 'help'
+
+    cmd, options, cmdoptions, args = dispatch._parse(['-h'])
+    assert cmd == 'help'
+    assert options['help'] == True
+
+
+def test__parse_subcmd_options():
+    cmd, options, cmdoptions, args = dispatch._parse(['push', '-b', 'http://localhost'])
+    assert cmd == 'push'
+    assert cmdoptions['browse'] == True
+
+
+def test__dispatch_debug():
+    assert dispatch._dispatch(['-d']) == 0
+
+
+def test__dispatch_help():
+    assert dispatch._dispatch(['-h']) == 0
+
+
+def test__dispatch_verbose():
+    assert dispatch._dispatch(['-v']) == 0
+
+
+def test__dispatch_version():
+    assert dispatch._dispatch(['--version']) == 0
+
+
+def test__dispatch_quiet():
+    assert dispatch._dispatch(['-q']) == 0

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -146,6 +146,22 @@ def test__dispatch_inapp(conf, commands):
     mock_func.assert_called_with(conf, conf.app_dir)
 
 
+@patch('couchapp.dispatch.commands')
+@patch('couchapp.dispatch.Config')
+def test__dispatch_update_commands(conf, commands):
+    conf = conf()
+    mock_func = Mock(return_value=10)
+    mock_mod = Mock()
+    mock_mod.cmdtable = {'mock': (mock_func, [], 'just for testing')}
+    conf.extensions = [mock_mod]
+    commands.table = {}
+    commands.globalopts = globalopts
+
+    assert dispatch._dispatch(['mock']) == 10
+    assert commands.table == mock_mod.cmdtable
+    assert mock_func.called
+
+
 @patch('couchapp.dispatch.logger')
 @patch('couchapp.dispatch._dispatch')
 def test_dispatch_AppError(_dispatch, logger):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import unittest2 as unittest
+
+from couchapp import dispatch
+from couchapp.errors import CommandLineError
+
+
+class DispatchTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_unknown_command(self):
+        with self.assertRaises(CommandLineError):
+            dispatch._dispatch(['unknown_command'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -89,24 +89,30 @@ def test__parse_subcmd_options():
     assert cmdoptions['browse'] == True
 
 
-def test__dispatch_debug():
+@patch('couchapp.dispatch.set_logging_level')
+def test__dispatch_debug(set_logging_level):
     assert dispatch._dispatch(['-d']) == 0
+    set_logging_level.assert_called_with(1)
 
 
 def test__dispatch_help():
     assert dispatch._dispatch(['-h']) == 0
 
 
-def test__dispatch_verbose():
+@patch('couchapp.dispatch.set_logging_level')
+def test__dispatch_verbose(set_logging_level):
     assert dispatch._dispatch(['-v']) == 0
+    set_logging_level.assert_called_with(1)
 
 
 def test__dispatch_version():
     assert dispatch._dispatch(['--version']) == 0
 
 
-def test__dispatch_quiet():
+@patch('couchapp.dispatch.set_logging_level')
+def test__dispatch_quiet(set_logging_level):
     assert dispatch._dispatch(['-q']) == 0
+    set_logging_level.assert_called_with(0)
 
 
 def test__dispatch_unknown_command():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -6,7 +6,7 @@ from couchapp import dispatch
 from couchapp.commands import globalopts
 from couchapp.errors import AppError, CommandLineError
 from nose.tools import assert_raises
-from mock import patch
+from mock import Mock, patch
 
 
 def test_parseopts_short_flag():
@@ -118,6 +118,20 @@ def test__dispatch_quiet(set_logging_level):
 def test__dispatch_unknown_command():
     with assert_raises(CommandLineError):
         dispatch._dispatch(['unknown_command'])
+
+
+@patch('couchapp.dispatch.commands')
+@patch('couchapp.dispatch.Config')
+def test__dispatch_inapp(conf, commands):
+    conf = conf()
+    conf.app_dir = '/mock_dir'
+    mock_func = Mock(return_value=10)
+    commands.table = {'mock': (mock_func, [], 'just for testing')}
+    commands.incouchapp = ['mock']
+    commands.globalopts = globalopts
+
+    assert dispatch._dispatch(['mock']) == 10
+    mock_func.assert_called_with(conf, conf.app_dir)
 
 
 @patch('couchapp.dispatch.logger')


### PR DESCRIPTION
Actually, not only test cases but also some code refine:

1. `couchapp/commands.py`: Increase the readability for `table`
2. `couchapp/dispatch.py`:
 1. Let  function `dispatch` catch `CommandLineError` correctly. Previously, we will get the full trace stack when we issue `couchapp unkown_command``
 2. Using `except ... as ...` syntax. The original syntax, `except ... , ...` is not compatible with python3. I will replace them gradually, if i encounter them

BTW, I can not understand the purpose of this [code] (https://github.com/couchapp/couchapp/blob/71cdf01610f6a409ef2bdd309a5cee610aa66ec5/couchapp/dispatch.py#L17-L20).