### PR TITLE
Improve coverage rate and some bugs fix for commands.py

### DIFF
--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -64,10 +64,11 @@ def push(conf, path, *args, **opts):
     doc = document(doc_path, create=False, docid=opts.get('docid'))
     if export:
         if opts.get('output'):
-            util.write_json(opts.get('output'), str(doc))
+            util.write_json(opts.get('output'), doc)
         else:
-            print str(doc)
+            print doc.to_json()
         return 0
+
     dbs = conf.get_dbs(dest)
 
     hook(conf, doc_path, "pre-push", dbs=dbs)
@@ -104,7 +105,7 @@ def pushapps(conf, source, dest, *args, **opts):
         docs = [doc.doc() for doc in apps]
         jsonobj = {'docs': docs}
         if opts.get('output'):
-            util.write_json(opts.get('output'), util.json.dumps(jsonobj))
+            util.write_json(opts.get('output'), jsonobj)
         else:
             print util.json.dumps(jsonobj)
         return 0

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -88,8 +88,11 @@ def pushapps(conf, source, dest, *args, **opts):
     dbs = conf.get_dbs(dest)
     apps = []
     source = os.path.normpath(os.path.join(os.getcwd(), source))
+    appdirs = util.discover_apps(source)
 
-    for appdir in util.discover_apps(source):
+    logger.debug('Discovered apps: {}'.format(appdirs))
+
+    for appdir in appdirs:
         doc = document(appdir)
         hook(conf, appdir, "pre-push", dbs=dbs, pushapps=True)
         if export or not noatomic:

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -166,8 +166,8 @@ def pushdocs(conf, source, dest, *args, **opts):
                 else:
                     docs1.append(doc)
             jsonobj = {'docs': docs}
-            if opts.get('output') is not None:
-                util.write_json(opts.get('output'), util.json.dumps(jsonobj))
+            if opts.get('output'):
+                util.write_json(opts.get('output'), jsonobj)
             else:
                 print util.json.dumps(jsonobj)
         else:
@@ -201,10 +201,8 @@ def pushdocs(conf, source, dest, *args, **opts):
 
 
 def clone(conf, source, *args, **opts):
-    if len(args) > 0:
-        dest = args[0]
-    else:
-        dest = None
+    dest = args[0] if len(args) > 0 else None
+
     hook(conf, dest, "pre-clone", source=source)
     clone_app.clone(source, dest, rev=opts.get('rev'))
     hook(conf, dest, "post-clone", source=source)

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -101,8 +101,7 @@ def pushapps(conf, source, dest, *args, **opts):
         return 0
 
     if export:
-        docs = []
-        docs.append([doc.doc() for doc in apps])
+        docs = [doc.doc() for doc in apps]
         jsonobj = {'docs': docs}
         if opts.get('output'):
             util.write_json(opts.get('output'), util.json.dumps(jsonobj))

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -6,12 +6,6 @@
 import logging
 import os
 
-try:
-    import desktopcouch
-except ImportError:
-    desktopcouch = None
-
-
 from couchapp import clone_app
 from couchapp.autopush.command import autopush, DEFAULT_UPDATE_DELAY
 from couchapp.errors import ResourceNotFound, AppError, BulkSaveError

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -223,12 +223,18 @@ def startapp(conf, *args, **opts):
     if util.iscouchapp(dest):
         raise AppError("can't create an app at '%s'. "
                        "One already exists here.".format(dest))
+    if util.findcouchapp(dest):
+        raise AppError("can't create an app inside another app '{0}'.".format(
+                       util.findcouchapp(dest)))
 
     generator.generate(dest, "startapp", name, **opts)
     return 0
 
 
 def generate(conf, path, *args, **opts):
+    '''
+    :param path: result of util.findcouchapp
+    '''
     dest = path
     if len(args) < 1:
         raise AppError("Can't generate function, name or path is missing")
@@ -246,10 +252,13 @@ def generate(conf, path, *args, **opts):
 
     if dest is None:
         if kind == "app":
-            dest = os.path.normpath(os.path.join(os.getcwd(), ".", name))
+            dest = os.path.normpath(os.path.join(os.getcwd(), name))
             opts['create'] = True
         else:
             raise AppError("You aren't in a couchapp.")
+    elif dest and kind == 'app':
+        raise AppError("can't create an app inside another app '{0}'.".format(
+                       dest))
 
     hook(conf, dest, "pre-generate")
     generator.generate(dest, kind, name, **opts)

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -90,7 +90,7 @@ def pushapps(conf, source, dest, *args, **opts):
     source = os.path.normpath(os.path.join(os.getcwd(), source))
     appdirs = util.discover_apps(source)
 
-    logger.debug('Discovered apps: {}'.format(appdirs))
+    logger.debug('Discovered apps: {0}'.format(appdirs))
 
     for appdir in appdirs:
         doc = document(appdir)

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -218,11 +218,11 @@ def startapp(conf, *args, **opts):
         dest = os.path.normpath(os.path.join(os.getcwd(), ".", name))
     elif len(args) == 2:
         name = args[1]
-        dest = os.path.normpath(os.path.join(args[0], args[1]))
+        dest = os.path.normpath(os.path.join(args[0], name))
 
-    if os.path.isfile(os.path.join(dest, ".couchapprc")):
-        raise AppError("can't create an app at '%s'. One already exists here" %
-                       dest)
+    if util.iscouchapp(dest):
+        raise AppError("can't create an app at '%s'. "
+                       "One already exists here.".format(dest))
 
     generator.generate(dest, "startapp", name, **opts)
     return 0

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -104,7 +104,7 @@ def pushapps(conf, source, dest, *args, **opts):
         docs = []
         docs.append([doc.doc() for doc in apps])
         jsonobj = {'docs': docs}
-        if opts.get('output') is not None:
+        if opts.get('output'):
             util.write_json(opts.get('output'), util.json.dumps(jsonobj))
         else:
             print util.json.dumps(jsonobj)

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -298,17 +298,16 @@ def vendor(conf, path, *args, **opts):
 
 
 def browse(conf, path, *args, **opts):
-    dest = None
-    doc_path = None
-    if len(args) < 2:
-        doc_path = path
-        if args:
-            dest = args[0]
+    if len(args) == 0:
+        dest = path
+        doc_path = '.'
     else:
-        doc_path = os.path.normpath(os.path.join(os.getcwd(), args[0]))
-        dest = args[1]
-    if doc_path is None:
-        raise AppError("You aren't in a couchapp.")
+        doc_path = path
+        dest = args[0]
+
+    doc_path = os.path.normpath(os.path.join(os.getcwd(), doc_path))
+    if not util.iscouchapp(doc_path):
+        raise AppError("Dir '{0}' is not a couchapp.".format(doc_path))
 
     conf.update(doc_path)
 

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -33,7 +33,7 @@ def init(conf, path, *args, **opts):
     if dest is None:
         raise AppError("Unknown dest")
 
-    document(dest, True)
+    document(dest, create=True)
 
 
 def push(conf, path, *args, **opts):
@@ -216,7 +216,6 @@ def startapp(conf, *args, **opts):
         name = args[0]
         dest = os.path.normpath(os.path.join(os.getcwd(), ".", name))
     elif len(args) == 2:
-
         name = args[1]
         dest = os.path.normpath(os.path.join(args[0], args[1]))
 

--- a/couchapp/localdoc.py
+++ b/couchapp/localdoc.py
@@ -431,6 +431,9 @@ class LocalDoc(object):
             return "%s/%s/index.html" % (dburl, self.docid)
         return False
 
+    def to_json(self):
+        return self.__str__()
+
 
 def document(path, create=False, docid=None, is_ddoc=True):
     return LocalDoc(path, create=create, docid=docid, is_ddoc=is_ddoc)

--- a/couchapp/util.py
+++ b/couchapp/util.py
@@ -229,11 +229,37 @@ def rcpath():
 
 
 def findcouchapp(p):
+    '''
+    Find couchapp top level dir from sub dir
+    '''
     while not os.path.isfile(os.path.join(p, ".couchapprc")):
         oldp, p = p, os.path.dirname(p)
         if p == oldp:
             return None
     return p
+
+
+def discover_apps(path):
+    '''
+    Given a path as parent dir, depth=1, return a tuple of the couchapps.
+
+    :type path: str
+    '''
+    return tuple(
+        x for x in os.listdir(path)
+        if os.path.isdir(os.path.join(path, x)) and
+           iscouchapp(os.path.join(path, x))
+    )
+
+
+def iscouchapp(path):
+    '''
+    A couchapp MUSH have ``.couchapprc``
+
+    :type path: str
+    :return: bool
+    '''
+    return os.path.isfile(os.path.join(path, '.couchapprc'))
 
 
 def in_couchapp():

--- a/couchapp/util.py
+++ b/couchapp/util.py
@@ -241,15 +241,21 @@ def findcouchapp(p):
 
 def discover_apps(path):
     '''
-    Given a path as parent dir, depth=1, return a tuple of the couchapps.
+    Given a path as parent dir, depth=1, return a list of the couchapps.
+    It will ignore all hidden dir.
 
     :type path: str
     '''
-    return tuple(
-        os.path.join(path, x) for x in os.listdir(path)
-        if os.path.isdir(os.path.join(path, x)) and
-           iscouchapp(os.path.join(path, x))
-    )
+    apps = []
+
+    for item in os.listdir(path):
+        full_path = os.path.join(path, item)
+        if item.startswith('.'):  # skip hidden file
+            continue
+        elif os.path.isdir(full_path) and iscouchapp(full_path):
+            apps.append(full_path)
+
+    return apps
 
 
 def iscouchapp(path):

--- a/couchapp/util.py
+++ b/couchapp/util.py
@@ -386,21 +386,26 @@ def read(fname, utf8=True, force_read=False):
 def write(fname, content):
     """ write content in a file
 
-    :attr fname: string,filename
-    :attr content: string
+    :type fname: string, filename
+    :type content: str
     """
     with open(fname, 'wb') as f:
         f.write(to_bytestring(content))
 
 
-def write_json(fname, content):
-    """ serialize content in json and save it
-
-    :attr fname: string
-    :attr content: string
-
+def write_json(fname, obj):
     """
-    write(fname, json.dumps(content).encode('utf-8'))
+    serialize obj in json and save it
+
+    :type fname: str
+    :param obj: serializable builtin type,
+        or any obj has ``to_json`` method
+    """
+    try:
+        val = json.dumps(obj).encode('utf-8')
+    except TypeError:
+        val = obj.to_json()
+    write(fname, val)
 
 
 def read_json(fname, use_environment=False, raise_on_error=False):

--- a/couchapp/util.py
+++ b/couchapp/util.py
@@ -246,7 +246,7 @@ def discover_apps(path):
     :type path: str
     '''
     return tuple(
-        x for x in os.listdir(path)
+        os.path.join(path, x) for x in os.listdir(path)
         if os.path.isdir(os.path.join(path, x)) and
            iscouchapp(os.path.join(path, x))
     )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@
 import unittest2 as unittest
 
 from couchapp import commands
+from mock import Mock, patch
 
 
 class CommandsTestCase(unittest.TestCase):
@@ -12,8 +13,16 @@ class CommandsTestCase(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_init_dest(self):
-        pass
+    @patch('couchapp.commands.document')
+    def test_init_dest(self, mock_doc):
+        commands.init(None, None, '/tmp/mk')
+        mock_doc.assert_called_once_with('/tmp/mk', True)
+
+    @patch('os.getcwd', return_value='/mock_dir')
+    @patch('couchapp.commands.document')
+    def test_init_dest_auto(self, mock_doc, mock_cwd):
+        commands.init(None, None)
+        mock_doc.assert_called_once_with('/mock_dir', True)
 
 
 if __name__ == '__main__':

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -129,3 +129,11 @@ def test_push_export_to_file(mock_doc, mock_util):
         '{"status": "ok"}'
     )
     assert ret_code == 0
+
+
+@raises(AppError)
+def test_push_app_path_error():
+    conf = NonCallableMock(name='conf')
+    dest = 'http://localhost'
+
+    commands.push(conf, None, dest)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,29 +1,27 @@
 # -*- coding: utf-8 -*-
 
-import unittest2 as unittest
-
 from couchapp import commands
+from couchapp.errors import AppError
+
 from mock import Mock, patch
+from nose.tools import raises
 
 
-class CommandsTestCase(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    @patch('couchapp.commands.document')
-    def test_init_dest(self, mock_doc):
-        commands.init(None, None, '/tmp/mk')
-        mock_doc.assert_called_once_with('/tmp/mk', create=True)
-
-    @patch('os.getcwd', return_value='/mock_dir')
-    @patch('couchapp.commands.document')
-    def test_init_dest_auto(self, mock_doc, mock_cwd):
-        commands.init(None, None)
-        mock_doc.assert_called_once_with('/mock_dir', create=True)
+@patch('couchapp.commands.document')
+def test_init_dest(mock_doc):
+    commands.init(None, None, '/tmp/mk')
+    mock_doc.assert_called_once_with('/tmp/mk', create=True)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@patch('os.getcwd', return_value='/mock_dir')
+@patch('couchapp.commands.document')
+def test_init_dest_auto(mock_doc, mock_cwd):
+    commands.init(None, None)
+    mock_doc.assert_called_once_with('/mock_dir', create=True)
+
+
+@raises(AppError)
+@patch('os.getcwd', return_value=None)
+@patch('couchapp.commands.document')
+def test_init_dest_auto(mock_doc, mock_cwd):
+    commands.init(None, None)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -47,11 +47,12 @@ def test_push_outside(mock_doc, mock_hook):
 
     conf.get_dbs.return_value = dest
 
-    commands.push(conf, path, appdir, dest)
+    ret_code = commands.push(conf, path, appdir, dest)
 
     mock_doc.assert_called_once_with(appdir, create=False, docid=None)
     mock_doc().push.assert_called_once_with(dest, False, False, False)
     assert mock_hook.call_args_list == hook_expect
+    assert ret_code == 0
 
 
 @patch('os.path.exists')
@@ -71,9 +72,10 @@ def test_push_with_pushdocs(mock_doc, mock_hook, mock_pushdocs, mock_exists):
         return docspath_ == docspath
     mock_exists.side_effect = check_docspath
 
-    commands.push(conf, appdir, dest)
+    ret_code = commands.push(conf, appdir, dest)
 
     mock_pushdocs.assert_called_once_with(conf, docspath, dest, dest)
+    assert ret_code == 0
 
 
 @patch('couchapp.commands.document', return_value='{"status": "ok"}',
@@ -85,8 +87,10 @@ def test_push_export_outside(mock_doc):
     conf = NonCallableMock(name='conf')
     appdir = '/mock_dir'
 
-    commands.push(conf, None, appdir, export=True)
+    ret_code = commands.push(conf, None, appdir, export=True)
+
     mock_doc.assert_called_once_with(appdir, create=False, docid=None)
+    assert ret_code == 0
 
 
 @patch('couchapp.commands.document', return_value='{"status": "ok"}',
@@ -100,8 +104,10 @@ def test_push_export_inside(mock_doc):
     conf = NonCallableMock(name='conf')
     appdir = '/mock_dir'
 
-    commands.push(conf, appdir, export=True)
+    ret_code = commands.push(conf, appdir, export=True)
+
     mock_doc.assert_called_once_with(appdir, create=False, docid=None)
+    assert ret_code == 0
 
 
 @patch('couchapp.commands.util')
@@ -115,10 +121,11 @@ def test_push_export_to_file(mock_doc, mock_util):
     appdir = '/mock_dir'
     output_file = '/file'
 
-    commands.push(conf, appdir, export=True, output=output_file)
+    ret_code = commands.push(conf, appdir, export=True, output=output_file)
 
     mock_doc.assert_called_once_with(appdir, create=False, docid=None)
     mock_util.write_json.assert_called_once_with(
         output_file,
         '{"status": "ok"}'
     )
+    assert ret_code == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -309,3 +309,76 @@ def test_clone_default(clone, hook):
     hook.assert_any_call(conf, dest, 'pre-clone', source=src)
     clone.assert_called_with(src, None, rev=None)
     hook.assert_any_call(conf, dest, 'post-clone', source=src)
+
+
+@patch('couchapp.commands.os.getcwd', return_value='/')
+@patch('couchapp.commands.generator.generate')
+def test_startapp_default(generate, getcwd):
+    '''
+    $ couchapp startapp {name}
+    '''
+    conf = NonCallableMock(name='conf')
+    name = 'mock'
+
+    ret_code = commands.startapp(conf, name)
+    assert ret_code == 0
+    generate.assert_called_with('/mock', 'startapp', name)
+
+
+@patch('couchapp.commands.os.getcwd')
+@patch('couchapp.commands.generator.generate')
+def test_startapp_default(generate, getcwd):
+    '''
+    $ couchapp startapp {dir} {name}
+    '''
+    conf = NonCallableMock(name='conf')
+    dir_ = '/'
+    name = 'mock'
+
+    ret_code = commands.startapp(conf, dir_, name)
+    assert ret_code == 0
+    assert not getcwd.called
+    generate.assert_called_with('/mock', 'startapp', name)
+
+
+@raises(AppError)
+@patch('couchapp.commands.os.getcwd', return_value='/')
+@patch('couchapp.commands.generator.generate')
+def test_startapp_without_name(generate, getcwd):
+    '''
+    $ couchapp startapp
+    '''
+    conf = NonCallableMock(name='conf')
+
+    ret_code = commands.startapp(conf)
+    assert not generate.called
+
+
+@raises(AppError)
+@patch('couchapp.commands.util.iscouchapp', return_value=True)
+@patch('couchapp.commands.os.getcwd', return_value='/')
+@patch('couchapp.commands.generator.generate')
+def test_startapp_exists(generate, getcwd, iscouchapp_):
+    '''
+    $ couchapp startapp {already exists app}
+    '''
+    conf = NonCallableMock(name='conf')
+
+    ret_code = commands.startapp(conf)
+    assert not generate.called
+
+
+@raises(AppError)
+@patch('couchapp.commands.util.iscouchapp', return_value=True)
+@patch('couchapp.commands.os.getcwd', return_value='/')
+@patch('couchapp.commands.generator.generate')
+def test_startapp_exists(generate, getcwd, iscouchapp_):
+    '''
+    $ couchapp startapp {already exists app}
+    '''
+    conf = NonCallableMock(name='conf')
+    name = 'mock'
+
+    ret_code = commands.startapp(conf, name)
+    assert iscouchapp_.assert_called_with('/mock')
+    assert not generate.called

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -102,3 +102,23 @@ def test_push_export_inside(mock_doc):
 
     commands.push(conf, appdir, export=True)
     mock_doc.assert_called_once_with(appdir, create=False, docid=None)
+
+
+@patch('couchapp.commands.util')
+@patch('couchapp.commands.document', return_value='{"status": "ok"}',
+       spec=document)
+def test_push_export_to_file(mock_doc, mock_util):
+    '''
+    $ couchapp push --export --output /path/to/json /appdir
+    '''
+    conf = NonCallableMock(name='conf')
+    appdir = '/mock_dir'
+    output_file = '/file'
+
+    commands.push(conf, appdir, export=True, output=output_file)
+
+    mock_doc.assert_called_once_with(appdir, create=False, docid=None)
+    mock_util.write_json.assert_called_once_with(
+        output_file,
+        '{"status": "ok"}'
+    )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+import unittest2 as unittest
+
+from couchapp import commands
+
+
+class CommandsTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_init_dest(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -184,9 +184,9 @@ def test_pushapps_output_null(discover_apps_, hook, document_, write_json):
 
     assert ret == 0
     discover_apps_.assert_called_with('/mock_dir')
-    hook.assert_not_called()
-    document_.assert_not_called()
-    write_json.assert_not_called()
+    assert not hook.called
+    assert not document_.called
+    assert not write_json.called
 
 
 @patch('couchapp.commands.util.json.dumps')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -16,13 +16,13 @@ class CommandsTestCase(unittest.TestCase):
     @patch('couchapp.commands.document')
     def test_init_dest(self, mock_doc):
         commands.init(None, None, '/tmp/mk')
-        mock_doc.assert_called_once_with('/tmp/mk', True)
+        mock_doc.assert_called_once_with('/tmp/mk', create=True)
 
     @patch('os.getcwd', return_value='/mock_dir')
     @patch('couchapp.commands.document')
     def test_init_dest_auto(self, mock_doc, mock_cwd):
         commands.init(None, None)
-        mock_doc.assert_called_once_with('/mock_dir', True)
+        mock_doc.assert_called_once_with('/mock_dir', create=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -78,8 +78,7 @@ def test_push_with_pushdocs(mock_doc, mock_hook, mock_pushdocs, mock_exists):
     assert ret_code == 0
 
 
-@patch('couchapp.commands.document', return_value='{"status": "ok"}',
-       spec=document)
+@patch('couchapp.commands.document', spec=document)
 def test_push_export_outside(mock_doc):
     '''
     $ couchapp push --export /path/to/app
@@ -93,8 +92,7 @@ def test_push_export_outside(mock_doc):
     assert ret_code == 0
 
 
-@patch('couchapp.commands.document', return_value='{"status": "ok"}',
-       spec=document)
+@patch('couchapp.commands.document', spec=document)
 def test_push_export_inside(mock_doc):
     '''
     In the app dir::

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -487,7 +487,7 @@ def test_generate_miss_name():
 
 
 @raises(AppError)
-def test_generate_view_outside_app():
+def test_generate_view_without_app():
     '''
     $ couchapp generate view myview
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -273,6 +273,7 @@ def test_pushapps_default(discover_apps_, hook, document_):
     conf.get_dbs.return_value = dbs
 
     ret_code = commands.pushapps(conf, '/mock_dir', dest)
+    assert ret_code == 0
     conf.get_dbs.assert_called_with(dest)
     hook.assert_any_call(conf, 'foo', 'pre-push', dbs=dbs, pushapps=True)
     hook.assert_any_call(conf, 'foo', 'post-push', dbs=dbs, pushapps=True)
@@ -291,3 +292,20 @@ def test_help_version():
     $ couchapp -h --version
     '''
     assert commands.usage(Mock(), version=True) == 0
+
+
+@patch('couchapp.commands.hook')
+@patch('couchapp.commands.clone_app.clone')
+def test_clone_default(clone, hook):
+    '''
+    $ couchapp clone {source}
+    '''
+    conf = NonCallableMock(name='conf')
+    src = 'http://localhost:5984/test'
+    dest = None
+
+    ret_code = commands.clone(conf, src)
+    assert ret_code == 0
+    hook.assert_any_call(conf, dest, 'pre-clone', source=src)
+    clone.assert_called_with(src, None, rev=None)
+    hook.assert_any_call(conf, dest, 'post-clone', source=src)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -23,5 +23,40 @@ def test_init_dest_auto(mock_doc, mock_cwd):
 @raises(AppError)
 @patch('os.getcwd', return_value=None)
 @patch('couchapp.commands.document')
-def test_init_dest_auto(mock_doc, mock_cwd):
+def test_init_dest_none(mock_doc, mock_cwd):
     commands.init(None, None)
+
+
+def test_push_outside():
+    '''
+    $ couchapp push /path/to/app
+    '''
+    pass
+
+
+@patch('couchapp.commands.document', return_value='{"status": "ok"}')
+def test_push_export_outside(mock_doc):
+    '''
+    $ couchapp push --export /path/to/app
+    '''
+    conf = Mock(name='conf')
+    appdir = '/mock_dir'
+
+    commands.push(conf, None, appdir, export=True)
+    mock_doc.assert_called_once_with(appdir, create=False, docid=None)
+    conf.update.assert_called_once_with(appdir)
+
+
+@patch('couchapp.commands.document', return_value='{"status": "ok"}')
+def test_push_export_inside(mock_doc):
+    '''
+    In the app dir::
+
+    $ couchapp push --export
+    '''
+    conf = Mock(name='conf')
+    appdir = '/mock_dir'
+
+    commands.push(conf, appdir, export=True)
+    mock_doc.assert_called_once_with(appdir, create=False, docid=None)
+    conf.update.assert_called_once_with(appdir)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -277,3 +277,17 @@ def test_pushapps_default(discover_apps_, hook, document_):
     hook.assert_any_call(conf, 'foo', 'pre-push', dbs=dbs, pushapps=True)
     hook.assert_any_call(conf, 'foo', 'post-push', dbs=dbs, pushapps=True)
     assert db.save_docs.called
+
+
+def test_version_help():
+    '''
+    $ couchapp version -h
+    '''
+    assert commands.version(Mock(), help=True) == 0
+
+
+def test_help_version():
+    '''
+    $ couchapp -h --version
+    '''
+    assert commands.usage(Mock(), version=True) == 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -358,7 +358,7 @@ def test_startapp_without_name(generate, getcwd):
 @patch('couchapp.commands.util.iscouchapp', return_value=True)
 @patch('couchapp.commands.os.getcwd', return_value='/')
 @patch('couchapp.commands.generator.generate')
-def test_startapp_exists(generate, getcwd, iscouchapp_):
+def test_startapp_exists(generate, getcwd, iscouchapp):
     '''
     $ couchapp startapp {already exists app}
     '''
@@ -372,7 +372,7 @@ def test_startapp_exists(generate, getcwd, iscouchapp_):
 @patch('couchapp.commands.util.iscouchapp', return_value=True)
 @patch('couchapp.commands.os.getcwd', return_value='/')
 @patch('couchapp.commands.generator.generate')
-def test_startapp_exists(generate, getcwd, iscouchapp_):
+def test_startapp_exists(generate, getcwd, iscouchapp):
     '''
     $ couchapp startapp {already exists app}
     '''
@@ -380,5 +380,54 @@ def test_startapp_exists(generate, getcwd, iscouchapp_):
     name = 'mock'
 
     ret_code = commands.startapp(conf, name)
-    assert iscouchapp_.assert_called_with('/mock')
+    assert iscouchapp.assert_called_with('/mock')
     assert not generate.called
+
+
+@patch('couchapp.commands.util.iscouchapp', return_value=True)
+@patch('couchapp.commands.document')
+def test_browse_default(document, iscouchapp):
+    '''
+    $ couchapp browse {app} {db url}
+    '''
+    conf = NonCallableMock(name='conf')
+    app = '/mock_dir'
+    dest = 'http://localhost:5984'
+    doc = document()
+
+    ret_code = commands.browse(conf, app, dest)
+    iscouchapp.assert_called_with('/mock_dir')
+    assert doc.browse.called
+
+
+@patch('os.getcwd', return_value='/mock_dir/app')
+@patch('couchapp.commands.util.iscouchapp', return_value=True)
+@patch('couchapp.commands.document')
+def test_browse_dest_only(document, iscouchapp, getcwd):
+    '''
+    $ couchapp browse {db url}
+    '''
+    conf = NonCallableMock(name='conf')
+    dest = 'http://localhost:5984'
+    doc = document()
+
+    ret_code = commands.browse(conf, dest)
+    iscouchapp.assert_called_with('/mock_dir/app')
+    assert doc.browse.called
+
+
+@raises(AppError)
+@patch('couchapp.commands.util.iscouchapp', return_value=False)
+@patch('couchapp.commands.document')
+def test_browse_exist(document, iscouchapp):
+    '''
+    $ couchapp browse {not app dir} {db url}
+    '''
+    conf = NonCallableMock(name='conf')
+    app = '/mock_dir/notapp'
+    dest = 'http://localhost:5984'
+    doc = document()
+
+    ret_code = commands.browse(conf, app, dest)
+    iscouchapp.assert_called_with('/mock_dir/notapp')
+    assert not doc.browse.called

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ def test_iscouchapp(isfile):
 @patch('couchapp.util.os.path.isdir', return_value=True)
 @patch('couchapp.util.iscouchapp', return_value=True)
 def test_discover_apps(iscouchapp_, isdir, listdir):
-    assert discover_apps('/mock_dir') == ('foo',)
+    assert discover_apps('/mock_dir') == ('/mock_dir/foo',)
     isdir.assert_called_with('/mock_dir/foo')
     listdir.assert_called_with('/mock_dir')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ def test_iscouchapp(isfile):
 @patch('couchapp.util.os.path.isdir', return_value=True)
 @patch('couchapp.util.iscouchapp', return_value=True)
 def test_discover_apps(iscouchapp_, isdir, listdir):
-    assert discover_apps('/mock_dir') == ('/mock_dir/foo',)
+    assert discover_apps('/mock_dir') == ['/mock_dir/foo']
     isdir.assert_called_with('/mock_dir/foo')
     listdir.assert_called_with('/mock_dir')
 
@@ -24,6 +24,18 @@ def test_discover_apps(iscouchapp_, isdir, listdir):
 @patch('couchapp.util.os.path.isdir', return_value=True)
 @patch('couchapp.util.iscouchapp', return_value=True)
 def test_discover_apps_relative_path(iscouchapp_, isdir, listdir):
-    assert discover_apps('mock_dir') == ('mock_dir/foo',)
+    assert discover_apps('mock_dir') == ['mock_dir/foo']
+    isdir.assert_called_with('mock_dir/foo')
+    listdir.assert_called_with('mock_dir')
+
+
+@patch('couchapp.util.os.listdir', return_value=['.git', 'foo'])
+@patch('couchapp.util.os.path.isdir', return_value=True)
+@patch('couchapp.util.iscouchapp', return_value=True)
+def test_discover_apps_hidden_file(iscouchapp_, isdir, listdir):
+    '''
+    Test case for a dir including hidden file
+    '''
+    assert discover_apps('mock_dir') == ['mock_dir/foo']
     isdir.assert_called_with('mock_dir/foo')
     listdir.assert_called_with('mock_dir')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,3 +18,12 @@ def test_discover_apps(iscouchapp_, isdir, listdir):
     assert discover_apps('/mock_dir') == ('foo',)
     isdir.assert_called_with('/mock_dir/foo')
     listdir.assert_called_with('/mock_dir')
+
+
+@patch('couchapp.util.os.listdir', return_value=['foo'])
+@patch('couchapp.util.os.path.isdir', return_value=True)
+@patch('couchapp.util.iscouchapp', return_value=True)
+def test_discover_apps_relative_path(iscouchapp_, isdir, listdir):
+    assert discover_apps('mock_dir') == ('mock_dir/foo',)
+    isdir.assert_called_with('mock_dir/foo')
+    listdir.assert_called_with('mock_dir')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from couchapp.util import discover_apps, iscouchapp
+
+from mock import patch
+
+
+@patch('couchapp.util.os.path.isfile', return_value=True)
+def test_iscouchapp(isfile):
+    assert iscouchapp('/mock_dir') == True
+    isfile.assert_called_with('/mock_dir/.couchapprc')
+
+
+@patch('couchapp.util.os.listdir', return_value=['foo'])
+@patch('couchapp.util.os.path.isdir', return_value=True)
+@patch('couchapp.util.iscouchapp', return_value=True)
+def test_discover_apps(iscouchapp_, isdir, listdir):
+    assert discover_apps('/mock_dir') == ('foo',)
+    isdir.assert_called_with('/mock_dir/foo')
+    listdir.assert_called_with('/mock_dir')


### PR DESCRIPTION
This branch is base on [test_dispatch](https://github.com/iblis17/couchapp/tree/test_dispatch) (issue #161).

I write test cases for the function in `commands.py` **except**:
1. Some parts of `pushapps`
2. whole `pushdocs`
3. whole `vendor`

Those function contain too many logical block. It's too complicated to write unit testing.
I will open new branch and issue to deal with them.

This PR also includes some bugs fix:
- iblis17/couchapp#2
- iblis17/couchapp#4
- iblis17/couchapp#6

BTW, if we need to examine the coverage report,
as README.rst says, run:
```
nosetests --tc-file=tests/config.ini --with-coverage --cover-package=couchapp --cover-html
```
Then, there is a dir `cover` generated by `converage.py`.
Please take a look at `couchapp_commands.html`.