### PR TITLE
[#174] Return `default` value properly

### DIFF
--- a/couchapp/config.py
+++ b/couchapp/config.py
@@ -70,7 +70,7 @@ class Config(object):
             return getattr(self, key)
         except AttributeError:
             pass
-        return self.conf[key]
+        return self.conf.get(key, default)
 
     def __getitem__(self, key):
         try:


### PR DESCRIPTION
The unit testing is hard to split from my working branch.

I will send them until I finished the whole testing of `config.py` :)