### PR TITLE
[config.py][#219] use deepcopy when `Config.load` copy param `default`

### DIFF
--- a/couchapp/config.py
+++ b/couchapp/config.py
@@ -6,6 +6,8 @@
 import re
 import os
 
+from copy import deepcopy
+
 from .client import Database
 from .errors import AppError
 from . import util
@@ -40,7 +42,7 @@ class Config(object):
 
         :type path: str or iterable
         """
-        conf = default if default is not None else {}
+        conf = deepcopy(default) if default is not None else {}
         paths = [path] if isinstance(path, basestring) else path
 
         for p in paths:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,6 +131,22 @@ class TestConfig():
         self.config.load('/mock/couchapp.conf')
         isfile.assert_called_with('/mock/couchapp.conf')
 
+    @patch('couchapp.config.util.read_json', return_value={'mock': True})
+    @patch('couchapp.config.os.path.isfile', return_value=True)
+    def test_load_deepcopy_default(self, isfile, read_json):
+        '''
+        Test case for checking Config.load() deepcopy param ``default``
+        '''
+        default = {'foo': {'bar': 'fake'}}
+
+        conf = self.config.load('/mock.conf', default=default)
+
+        assert conf == {
+            'foo': {'bar': 'fake'},
+            'mock': True
+            }
+        assert default == {'foo': {'bar': 'fake'}}
+
     @patch('couchapp.config.Config.load', return_value='mock')
     def test_load_local(self, load):
         '''


### PR DESCRIPTION
test case included.