### PR TITLE
[#180] Separate logical blocks: vars init

### DIFF
--- a/couchapp/clone_app.py
+++ b/couchapp/clone_app.py
@@ -24,41 +24,38 @@ class clone(object):
     :param source: the http/https uri of design document
     """
     def __init__(self, source, dest=None, rev=None):
+        self.source = source
+        self.dest = dest
+        self.rev = rev
+
+        # init self.docid & self.dburl
         try:
-            dburl, docid = source.split('_design/')
+            self.dburl, self.docid = self.source.split('_design/')
         except ValueError:
-            raise AppError("{0} isn't a valid source".format(source))
+            raise AppError("{0} isn't a valid source".format(self.source))
 
-        if not dest:
-            dest = docid
+        if not self.dest:
+            self.dest = self.docid
 
-        path = os.path.normpath(os.path.join(os.getcwd(), dest))
-        if not os.path.exists(path):
-            os.makedirs(path)
+        # init self.path
+        self.init_path()
 
-        db = client.Database(dburl[:-1], create=False)
-        if not rev:
-            doc = db.open_doc("_design/%s" % docid)
+        # init self.db
+        self.db = client.Database(self.dburl[:-1], create=False)
+        if not self.rev:
+            self.doc = self.db.open_doc('_design/{0}'.format(self.docid))
         else:
-            doc = db.open_doc("_design/%s" % docid, rev=rev)
-        docid = doc['_id']
+            self.doc = self.db.open_doc('_design/{0}'.format(self.docid), rev=self.rev)
+        self.docid = self.doc['_id']
 
-        metadata = doc.get('couchapp', {})
-
-        # get manifest
-        manifest = metadata.get('manifest', {})
-
-        # get signatures
-        signatures = metadata.get('signatures', {})
-
-        # get objects refs
-        objects = metadata.get('objects', {})
+        # init metadata
+        self.init_metadata()
 
         # create files from manifest
-        if manifest:
-            for filename in manifest:
+        if self.manifest:
+            for filename in self.manifest:
                 logger.debug("clone property: %s" % filename)
-                filepath = os.path.join(path, filename)
+                filepath = os.path.join(self.path, filename)
                 if filename.endswith('/'):
                     if not os.path.isdir(filepath):
                         os.makedirs(filepath)
@@ -67,7 +64,7 @@ class clone(object):
                 else:
                     parts = util.split_path(filename)
                     fname = parts.pop()
-                    v = doc
+                    v = self.doc
                     while 1:
                         try:
                             for key in parts:
@@ -85,8 +82,8 @@ class clone(object):
 
                         if isinstance(content, basestring):
                             _ref = md5(util.to_bytestring(content)).hexdigest()
-                            if objects and _ref in objects:
-                                content = objects[_ref]
+                            if self.objects and _ref in self.objects:
+                                content = self.objects[_ref]
 
                             if content.startswith('base64-encoded;'):
                                 content = base64.b64decode(content[15:])
@@ -104,7 +101,7 @@ class clone(object):
                         util.write(filepath, content)
 
                         # remove the key from design doc
-                        temp = doc
+                        temp = self.doc
                         for key2 in parts:
                             if key2 == key:
                                 if not temp[key2]:
@@ -114,11 +111,11 @@ class clone(object):
 
         # second pass for missing key or in case
         # manifest isn't in app
-        for key in doc.iterkeys():
+        for key in self.doc.iterkeys():
             if key.startswith('_'):
                 continue
             elif key in ('couchapp'):
-                app_meta = copy.deepcopy(doc['couchapp'])
+                app_meta = copy.deepcopy(self.doc['couchapp'])
                 if 'signatures' in app_meta:
                     del app_meta['signatures']
                 if 'manifest' in app_meta:
@@ -128,13 +125,13 @@ class clone(object):
                 if 'length' in app_meta:
                     del app_meta['length']
                 if app_meta:
-                    couchapp_file = os.path.join(path, 'couchapp.json')
+                    couchapp_file = os.path.join(self.path, 'couchapp.json')
                     util.write_json(couchapp_file, app_meta)
             elif key in ('views'):
-                vs_dir = os.path.join(path, key)
+                vs_dir = os.path.join(self.path, key)
                 if not os.path.isdir(vs_dir):
                     os.makedirs(vs_dir)
-                for vsname, vs_item in doc[key].iteritems():
+                for vsname, vs_item in self.doc[key].iteritems():
                     vs_item_dir = os.path.join(vs_dir, vsname)
                     if not os.path.isdir(vs_item_dir):
                         os.makedirs(vs_item_dir)
@@ -143,26 +140,26 @@ class clone(object):
                         util.write(filename, func)
                         logger.warning("clone view not in manifest: %s" % filename)
             elif key in ('shows', 'lists', 'filter', 'updates'):
-                showpath = os.path.join(path, key)
+                showpath = os.path.join(self.path, key)
                 if not os.path.isdir(showpath):
                     os.makedirs(showpath)
-                for func_name, func in doc[key].iteritems():
+                for func_name, func in self.doc[key].iteritems():
                     filename = os.path.join(showpath, '%s.js' % func_name)
                     util.write(filename, func)
                     logger.warning(
                         "clone show or list not in manifest: %s" % filename)
             else:
-                filedir = os.path.join(path, key)
+                filedir = os.path.join(self.path, key)
                 if os.path.exists(filedir):
                     continue
                 else:
                     logger.warning("clone property not in manifest: %s" % key)
-                    if isinstance(doc[key], (list, tuple,)):
-                        util.write_json(filedir + ".json", doc[key])
-                    elif isinstance(doc[key], dict):
+                    if isinstance(self.doc[key], (list, tuple,)):
+                        util.write_json(filedir + ".json", self.doc[key])
+                    elif isinstance(self.doc[key], dict):
                         if not os.path.isdir(filedir):
                             os.makedirs(filedir)
-                        for field, value in doc[key].iteritems():
+                        for field, value in self.doc[key].iteritems():
                             fieldpath = os.path.join(filedir, field)
                             if isinstance(value, basestring):
                                 if value.startswith('base64-encoded;'):
@@ -171,26 +168,26 @@ class clone(object):
                             else:
                                 util.write_json(fieldpath + '.json', value)
                     else:
-                        value = doc[key]
+                        value = self.doc[key]
                         if not isinstance(value, basestring):
                             value = str(value)
                         util.write(filedir, value)
 
         # save id
-        idfile = os.path.join(path, '_id')
-        util.write(idfile, doc['_id'])
+        idfile = os.path.join(self.path, '_id')
+        util.write(idfile, self.doc['_id'])
 
-        util.write_json(os.path.join(path, '.couchapprc'), {})
+        util.write_json(os.path.join(self.path, '.couchapprc'), {})
 
-        if '_attachments' in doc:  # process attachments
-            attachdir = os.path.join(path, '_attachments')
+        if '_attachments' in self.doc:  # process attachments
+            attachdir = os.path.join(self.path, '_attachments')
             if not os.path.isdir(attachdir):
                 os.makedirs(attachdir)
 
-            for filename in doc['_attachments'].iterkeys():
+            for filename in self.doc['_attachments'].iterkeys():
                 if filename.startswith('vendor'):
                     attach_parts = util.split_path(filename)
-                    vendor_attachdir = os.path.join(path, attach_parts.pop(0),
+                    vendor_attachdir = os.path.join(self.path, attach_parts.pop(0),
                                                     attach_parts.pop(0),
                                                     '_attachments')
                     filepath = os.path.join(vendor_attachdir, *attach_parts)
@@ -201,14 +198,14 @@ class clone(object):
                 if not os.path.isdir(currentdir):
                     os.makedirs(currentdir)
 
-                if signatures.get(filename) != util.sign(filepath):
-                    resp = db.fetch_attachment(docid, filename)
+                if self.signatures.get(filename) != util.sign(filepath):
+                    resp = self.db.fetch_attachment(self.docid, filename)
                     with open(filepath, 'wb') as f:
                         for chunk in resp.body_stream():
                             f.write(chunk)
                     logger.debug("clone attachment: %s" % filename)
 
-        logger.info("%s cloned in %s" % (source, dest))
+        logger.info("%s cloned in %s" % (self.source, self.dest))
 
     def __new__(cls, *args, **kwargs):
         obj = super(clone, cls).__new__(cls)
@@ -217,3 +214,22 @@ class clone(object):
         obj.__init__(*args, **kwargs)
 
         return None
+
+    def init_path(self):
+        self.path = os.path.normpath(os.path.join(os.getcwd(), self.dest))
+
+        if not os.path.exists(self.path):
+            os.makedirs(self.path)
+
+    def init_metadata(self):
+        '''
+        Setup
+            - self.manifest
+            - self.signatures
+            - self.objects: objects refs
+        '''
+        metadata = self.doc.get('couchapp', {})
+
+        self.manifest = metadata.get('manifest', {})
+        self.signatures = metadata.get('signatures', {})
+        self.objects = metadata.get('objects', {})


### PR DESCRIPTION
1. Rename vars
  - source -> self.source
  - dest -> self.dest
  - rev -> self.rev
  - dburl -> self.dburl
  - docid -> self.docid
  - path -> self.path
  - doc -> self.doc
  - manifest -> self.manifest
  - signatures -> self.signatures
  - objects -> self.objects

2. logical block: `init_path`

3. logical block: `init_metadata`