### PR TITLE
[util] deprecate `popen3`, new helper function: `sh_open`

### DIFF
--- a/couchapp/util.py
+++ b/couchapp/util.py
@@ -6,14 +6,16 @@
 from __future__ import with_statement
 
 import codecs
-from hashlib import md5
 import imp
 import inspect
 import logging
 import os
 import re
 import string
+import subprocess
 import sys
+
+from hashlib import md5
 
 from couchapp.errors import ScriptError
 
@@ -31,21 +33,6 @@ except ImportError:
         """)
 
 logger = logging.getLogger(__name__)
-
-try:  # python 2.6, use subprocess
-    import subprocess
-    subprocess.Popen  # trigger ImportError early
-    closefds = os.name == 'posix'
-
-    def popen3(cmd, mode='t', bufsize=0):
-        p = subprocess.Popen(cmd, shell=True, bufsize=bufsize,
-                             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, close_fds=closefds)
-        p.wait()
-        return (p.stdin, p.stdout, p.stderr)
-except ImportError:
-    subprocess = None
-    popen3 = os.popen3
 
 try:
     from importlibe import import_module
@@ -503,11 +490,10 @@ class ShellScript(object):
     def hook(self, *args, **options):
         cmd = self.cmd + " "
 
-        (child_stdin, child_stdout, child_stderr) = popen3(cmd)
-        err = child_stderr.read()
-        if err:
-            raise ScriptError(str(err))
-        return (child_stdout.read())
+        child_stdout, child_stderr = sh_open(cmd)
+        if child_stderr:
+            raise ScriptError(str(child_stderr))
+        return child_stdout
 
 
 def hook_uri(uri, cfg):
@@ -530,3 +516,22 @@ def remove_comments(t):
             return ""
         return s
     return re.sub(re_comment, replace, t)
+
+
+def sh_open(cmd, bufsize=0):
+    '''
+    run shell command with :mod:`subprocess`
+
+    :param str cmd: the command string
+    :param int bufsize: the bufsize passed to ``subprocess.Popen``
+    :return:  a tuple contains (stdout, stderr)
+    '''
+    closefds = (os.name == 'posix')
+
+    p = subprocess.Popen(cmd, shell=True, bufsize=bufsize,
+                         stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, close_fds=closefds)
+    # use ``communicate`` to avoid PIPE deadlock
+    out, err = p.communicate()
+
+    return (out, err)

--- a/couchapp/vendors/backends/git.py
+++ b/couchapp/vendors/backends/git.py
@@ -6,7 +6,7 @@
 import logging
 
 from couchapp.errors import VendorError
-from couchapp.util import locate_program, popen3
+from couchapp.util import locate_program, sh_open
 from couchapp.vendors.backends.base import BackendVendor
 
 logger = logging.getLogger(__name__)
@@ -37,8 +37,7 @@ class GitVendor(BackendVendor):
         cmd += " clone %s %s" % (url, path)
 
        # exec cmd
-        (child_stdin, child_stdout, child_stderr) = popen3(cmd)
-        err = child_stderr.read()
-        if err:
-            raise VendorError(str(err))
+        child_stdout, child_stderr = sh_open(cmd)
+        if child_stderr:
+            raise VendorError(str(child_stderr))
         logger.debug(child_stdout.read())

--- a/couchapp/vendors/backends/hg.py
+++ b/couchapp/vendors/backends/hg.py
@@ -6,7 +6,7 @@
 import logging
 
 from couchapp.errors import VendorError
-from couchapp.util import locate_program, popen3
+from couchapp.util import locate_program, sh_open
 from couchapp.vendors.backends.base import BackendVendor
 
 logger = logging.getLogger(__name__)
@@ -38,9 +38,8 @@ class HgVendor(BackendVendor):
         cmd += " clone %s %s" % (url, path)
 
        # exec cmd
-        (child_stdin, child_stdout, child_stderr) = popen3(cmd)
-        err = child_stderr.read()
-        if err:
-            raise VendorError(str(err))
+        child_stdout, child_stderr = sh_open(cmd)
+        if child_stderr:
+            raise VendorError(str(child_stderr))
 
         logger.debug(child_stdout.read())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@
 import os
 
 from couchapp.util import discover_apps, iscouchapp, rcpath, split_path
+from couchapp.util import sh_open
 
 from mock import patch
 
@@ -103,3 +104,12 @@ def test_split_path_abs():
     '''
     path = os.path.realpath('/foo/bar')
     assert split_path(path) == [os.path.realpath('/foo'), 'bar']
+
+
+def test_sh_open():
+    '''
+    Test case for ``util.sh_open``
+    '''
+    out, err = sh_open('echo mock')
+    assert out.startswith('mock'), out
+    assert not err, err


### PR DESCRIPTION
Though original implementation invoked `subprocess.Popen`,
the `Popen.wait` cause intermittent test failures
due to PIPE deadlock.

In the new helper function, we use `Popen.communicate` instead.

ref: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait