### PR TITLE
let `couchapp ini newdir` create dir correctly

### DIFF
--- a/couchapp/localdoc.py
+++ b/couchapp/localdoc.py
@@ -24,9 +24,9 @@ except ImportError:
     desktopcouch = None
 
 
+from couchapp import util
 from couchapp.errors import ResourceNotFound, AppError
 from couchapp.macros import package_shows, package_views
-from couchapp import util
 
 if os.name == 'nt':
     def _replace_backslash(name):
@@ -94,8 +94,7 @@ class LocalDoc(object):
         return util.json.dumps(self.doc())
 
     def create(self):
-        if not os.path.isdir(self.docdir):
-            logger.error("%s directory doesn't exist." % self.docdir)
+        util.setup_dir(self.docdir, require_empty=False)
 
         rcfile = os.path.join(self.docdir, '.couchapprc')
         ignfile = os.path.join(self.docdir, '.couchappignore')

--- a/couchapp/util.py
+++ b/couchapp/util.py
@@ -17,7 +17,7 @@ import sys
 
 from hashlib import md5
 
-from couchapp.errors import ScriptError
+from couchapp.errors import AppError, ScriptError
 
 try:
     import json
@@ -545,3 +545,28 @@ def sh_open(cmd, bufsize=0):
     out, err = p.communicate()
 
     return (out, err)
+
+
+def is_empty_dir(path):
+    if not os.listdir(path):
+        return True
+    return False
+
+
+def setup_dir(path, require_empty=True):
+    '''
+    If dir exists, check it empty or not.
+    If dir does not exist, make one.
+    '''
+    isdir = os.path.isdir(path)
+
+    if isdir and not require_empty:
+        return
+    elif isdir and require_empty and is_empty_dir(path):
+        return
+    elif isdir and require_empty and not is_empty_dir(path):
+        raise AppError("dir '{0}' is not empty".format(path))
+    elif os.path.exists(path) and not isdir:
+        raise AppError("'{0}': File exists".format(path))
+
+    os.mkdir(path)


### PR DESCRIPTION
If we `init` a non-exists dir, we will get this:
```
└─[iblis@imfsa Oops]% couchapp init newdir
2016-02-29 23:35:11 [ERROR] /tmp/bb/couchapp/t/newdir directory doesn't exist.
2016-02-29 23:35:11 [CRITICAL] [Errno 2] No such file or directory: '/tmp/bb/couchapp/t/newdir/.couchapprc'

Traceback (most recent call last):
  File "/tmp/bb/couchapp/couchapp/dispatch.py", line 45, in dispatch
    return _dispatch(args)
  File "/tmp/bb/couchapp/couchapp/dispatch.py", line 92, in _dispatch
    return fun(conf, conf.app_dir, *args, **opts)
  File "/tmp/bb/couchapp/couchapp/commands.py", line 36, in init
    document(dest, create=True)
  File "/tmp/bb/couchapp/couchapp/localdoc.py", line 440, in document
    is_ddoc=is_ddoc)
  File "/tmp/bb/couchapp/couchapp/localdoc.py", line 72, in __init__
    self.create()
  File "/tmp/bb/couchapp/couchapp/localdoc.py", line 103, in create
    util.write_json(rcfile, {})
  File "/tmp/bb/couchapp/couchapp/util.py", line 412, in write_json
    write(fname, val)
  File "/tmp/bb/couchapp/couchapp/util.py", line 396, in write
    with open(fname, 'wb') as f:
IOError: [Errno 2] No such file or directory: '/tmp/bb/couchapp/t/newdir/.couchapprc'
```