### PR TITLE
proposal of new `init` command

### DIFF
--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -264,15 +264,18 @@ def generate(conf, path, *args, **opts):
         dest = args[1]
         name = args[2]
 
+    if kind == 'app':  # deprecated warning
+        logger.warning('"genrate app" will be deprecated in future release. '
+                       'Please use "init -t TEMPLATE" instead.')
+        args = (dest,) if dest is not None else tuple()
+        kwargs = {
+            'template': opts['template'] if opts['template'] else 'app',
+            'empty': False
+        }
+        return init(conf, *args, **kwargs)
+
     if dest is None:
-        if kind == "app":
-            dest = os.path.normpath(os.path.join(os.getcwd(), name))
-            opts['create'] = True
-        else:
-            raise AppError("You aren't in a couchapp.")
-    elif dest and kind == 'app':
-        raise AppError("can't create an app inside another app '{0}'.".format(
-                       dest))
+        raise AppError("You aren't in a couchapp.")
 
     hook(conf, dest, "pre-generate")
     generator.generate(dest, kind, name, **opts)

--- a/couchapp/commands.py
+++ b/couchapp/commands.py
@@ -236,25 +236,13 @@ def clone(conf, source, *args, **opts):
 
 
 def startapp(conf, *args, **opts):
-    if len(args) < 1:
-        raise AppError("Can't start an app, name or path is missing")
+    opts['empty'] = False
+    opts['template'] = ''
 
-    if len(args) == 1:
-        name = args[0]
-        dest = os.path.normpath(os.path.join(os.getcwd(), ".", name))
-    elif len(args) == 2:
-        name = args[1]
-        dest = os.path.normpath(os.path.join(args[0], name))
+    logger.warning('"startapp" will be deprecated in future release. '
+                   'Please use "init" instead.')
 
-    if util.iscouchapp(dest):
-        raise AppError("can't create an app at '{0}'. "
-                       "One already exists here.".format(dest))
-    if util.findcouchapp(dest):
-        raise AppError("can't create an app inside another app '{0}'.".format(
-                       util.findcouchapp(dest)))
-
-    generator.generate(dest, "startapp", name, **opts)
-    return 0
+    return init(conf, *args, **opts)
 
 
 def generate(conf, path, *args, **opts):

--- a/couchapp/generator.py
+++ b/couchapp/generator.py
@@ -12,7 +12,7 @@ import sys
 
 from couchapp.errors import AppError
 from couchapp import localdoc
-from couchapp.util import is_py2exe, is_windows, relpath, user_path
+from couchapp.util import is_py2exe, is_windows, relpath, setup_dir, user_path
 
 __all__ = ["generate_app", "generate_function", "generate"]
 
@@ -26,12 +26,20 @@ DEFAULT_APP_TREE = ['_attachments',
                     'views']
 
 
-def start_app(path):
-    try:
-        os.makedirs(path)
-    except OSError, e:
-        errno, message = e
-        raise AppError("Can't create a CouchApp in %s: %s" % (path, message))
+def init_basic(path):
+    '''
+    Generate a basic CouchApp which contain following files::
+
+        /path/
+            .couchapprc
+            .couchappignore
+            _attachments/
+            lists/
+            shows/
+            updates/
+            views/
+    '''
+    setup_dir(path, require_empty=True)
 
     for n in DEFAULT_APP_TREE:
         tp = os.path.join(path, n)
@@ -40,10 +48,9 @@ def start_app(path):
     fid = os.path.join(path, '_id')
     if not os.path.isfile(fid):
         with open(fid, 'wb') as f:
-            f.write('_design/%s' % os.path.split(path)[1])
+            f.write('_design/{0}'.format(os.path.split(path)[1]))
 
     localdoc.document(path, create=True)
-    logger.info("%s created." % path)
 
 
 def generate_app(path, template=None, create=False):

--- a/couchapp/generator.py
+++ b/couchapp/generator.py
@@ -14,7 +14,7 @@ from couchapp.errors import AppError
 from couchapp import localdoc
 from couchapp.util import is_py2exe, is_windows, relpath, setup_dir, user_path
 
-__all__ = ["generate_app", "generate_function", "generate"]
+__all__ = ["init_basic", "init_template", "generate_function", "generate"]
 
 logger = logging.getLogger(__name__)
 
@@ -53,24 +53,14 @@ def init_basic(path):
     localdoc.document(path, create=True)
 
 
-def generate_app(path, template=None, create=False):
-    """ Generates a CouchApp in app_dir
-
-    :attr verbose: boolean, default False
-    :return: boolean, dict. { 'ok': True } if ok,
-    { 'ok': False, 'error': message }
-    if something was wrong.
-    """
-
+def init_template(path, template=None):
+    '''
+    Generates a CouchApp via template
+    '''
     TEMPLATES = ['app']
-    prefix = ''
-    if template is not None:
-        prefix = os.path.join(*template.split('/'))
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        errno, message = e
-        raise AppError("Can't create a CouchApp in %s: %s" % (path, message))
+    prefix = os.path.join(*template.split('/')) if template is not None else ''
+
+    setup_dir(path, require_empty=True)
 
     for n in DEFAULT_APP_TREE:
         tp = os.path.join(path, n)
@@ -99,12 +89,9 @@ def generate_app(path, template=None, create=False):
     fid = os.path.join(appdir, '_id')
     if not os.path.isfile(fid):
         with open(fid, 'wb') as f:
-            f.write('_design/%s' % os.path.split(appdir)[1])
+            f.write('_design/{0}'.format(os.path.split(appdir)[1]))
 
-    if create:
-        localdoc.document(path, create=True)
-
-    logger.info("%s generated." % path)
+    localdoc.document(path, create=True)
 
 
 def generate_function(path, kind, name, template=None):

--- a/couchapp/generator.py
+++ b/couchapp/generator.py
@@ -222,18 +222,13 @@ def find_template_dir(name, directory=''):
 
 
 def generate(path, kind, name, **opts):
-    if kind not in ['startapp', 'app', 'view', 'list', 'show', 'filter',
+    if kind not in ['view', 'list', 'show', 'filter',
                     'function', 'vendor', 'update', 'spatial']:
-        raise AppError(
-            "Can't generate %s in your couchapp. generator is unknown" % kind)
+        raise AppError("Can't generate {0} in your couchapp. "
+                       'generator is unknown'.format(kind))
 
-    if kind == "app":
-        generate_app(path, template=opts.get("template"),
-                     create=opts.get('create', False))
-    elif kind == "startapp":
-        start_app(path)
-    else:
-        if name is None:
-            raise AppError("Can't generate %s function, name is missing" %
-                           kind)
-        generate_function(path, kind, name, opts.get("template"))
+    if name is None:
+        raise AppError("Can't generate {0} function, "
+                       "name is missing".format(kind))
+
+    generate_function(path, kind, name, opts.get("template"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,10 +65,10 @@ class CliTestCase(unittest.TestCase):
         self.assertIsNotNone(design_doc)
         return design_doc
 
-    def testGenerate(self):
+    def test_init_template(self):
         os.chdir(self.tempdir)
         child_stdout, child_stderr = sh_open(
-            '{0} generate my-app'.format(self.cmd))
+            '{0} init -t app my-app'.format(self.cmd))
         appdir = os.path.join(self.tempdir, 'my-app')
         self.assertTrue(os.path.isdir(appdir))
         cfile = os.path.join(appdir, '.couchapprc')
@@ -229,9 +229,9 @@ class CliTestCase(unittest.TestCase):
 
         # create 2 apps
         child_stdout, child_stderr = sh_open(
-            '{0} generate docs/app1'.format(self.cmd))
+            '{0} init -t app docs/app1'.format(self.cmd))
         child_stdout, child_stderr = sh_open(
-            '{0} generate docs/app2'.format(self.cmd))
+            '{0} init -t app docs/app2'.format(self.cmd))
 
         child_stdout, child_stderr = sh_open(
             '{0} pushapps docs/ {1}couchapp-test'.format(self.cmd, url))
@@ -247,9 +247,9 @@ class CliTestCase(unittest.TestCase):
 
         # create 2 apps
         child_stdout, child_stderr = sh_open(
-            '{0} generate docs/app1'.format(self.cmd))
+            '{0} init -t app docs/app1'.format(self.cmd))
         child_stdout, child_stderr = sh_open(
-            '{0} generate docs/app2'.format(self.cmd))
+            '{0} init -t app docs/app2'.format(self.cmd))
 
         child_stdout, child_stderr = sh_open(
             '{0} pushdocs docs/ {1}couchapp-test'.format(self.cmd, url))


### PR DESCRIPTION
Hi @BigBlueHat 
This PR is a proposal for the #198.

I introduce the different levels of 'init':
1. default
2. empty
3. template

- level 'default', this will invoke `couchapp.generator.init_basic`
```shell
  $ couchapp init dir
    dir/
      .couchapprc
      .couchappignore
      _attachments/
      lists/
      shows/
      updates/
      views/
```

- level 'empty'
```shell
  $ couchapp init -e dir
    dir/
      .couchapprc
      .couchappignore
```

- level 'template', invoke `couchapp.generator.init_template`
```shell
  $ couchapp init -t mytemplate dir
    dir/
      .couchapprc
      .couchappignore
      ...
      vendors
      ...
```